### PR TITLE
Dev branch

### DIFF
--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1618,6 +1618,42 @@ void F3DStarter::AddCommands()
     return f3d::options::parse<bool>(args[0]);
   };
 
+  interactor.addCommand("remove_file_groups",
+    [this](const std::vector<std::string>&)
+    { 
+      auto& internals = *this->Internals;
+
+      // Eliminate running animations before scene clearing
+      if (!internals.AppOptions.NoRender)
+      {
+        internals.Engine->getInteractor().stopAnimation();
+      }
+
+      auto& engine = *internals.Engine;
+      auto& scene = engine.getScene();
+      scene.clear(); // Clear display
+
+      // Remove file groups and cached files
+      internals.FilesGroups.clear();
+      internals.LoadedFiles.clear();
+
+      // Revert to default window name
+      f3d::window& window = this->Internals->Engine->getWindow();
+      window.setWindowName(F3D::AppTitle).setIcon(F3DIcon, sizeof(F3DIcon));
+
+      // Re-display drop zone, eliminate files
+      f3d::options& opts = engine.getOptions();
+      opts.ui.dropzone = true;
+      opts.ui.filename_info.clear();
+    });
+
+  interactor.addCommand("load_next_file_group",
+    [this](const std::vector<std::string>& args)
+    {
+      this->LoadRelativeFileGroup(
+        +1, parse_optional_bool_flag(args, "load_next_file_group", false));
+    });
+
   interactor.addCommand("load_previous_file_group",
     [this](const std::vector<std::string>& args)
     {

--- a/application/F3DStarter.cxx
+++ b/application/F3DStarter.cxx
@@ -1647,13 +1647,6 @@ void F3DStarter::AddCommands()
       opts.ui.filename_info.clear();
     });
 
-  interactor.addCommand("load_next_file_group",
-    [this](const std::vector<std::string>& args)
-    {
-      this->LoadRelativeFileGroup(
-        +1, parse_optional_bool_flag(args, "load_next_file_group", false));
-    });
-
   interactor.addCommand("load_previous_file_group",
     [this](const std::vector<std::string>& args)
     {

--- a/doc/user/COMMANDS.md
+++ b/doc/user/COMMANDS.md
@@ -70,6 +70,8 @@ The F3D application provides a few more commands.
 
 `reload_current_file_group`: A specific command to reload the current file or file group. No argument.
 
+`remove_file_groups`: A specific command to remove all loaded files. No argument.
+
 `add_current_directories`: A specific command to add all files from the current file or file group directories. No argument.
 
 `take_screenshot [filename]`: A specific command to [take a screenshot](INTERACTIONS.md#taking-screenshots). If filename is not specified,


### PR DESCRIPTION
Adds a remove_file_groups command as per issue #1897, implementing a console command that takes no arguments and removes all loaded files in f3d. The background HDR is not removed since the command only uses scene.clear() as requested.